### PR TITLE
Fixes #4 - Update the Tagline to refer to WildAid, not React 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="O-FISH (Officer Fishery Information Sharing Hub) is a multi-platform application that enables officers to browse and record boarding report data from their mobile devices. See WildAid Marine program site: https://marine.wildaid.org/"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
Fixes #4
[-] Site description meta changed to: "O-FISH (Officer Fishery Information Sharing Hub) is a multi-platform application that enables officers to browse and record boarding report data from their mobile devices. See WildAid Marine program site: https://marine.wildaid.org/"