### PR TITLE
Edit agency functionality

### DIFF
--- a/src/components/agencies/agencies.component.js
+++ b/src/components/agencies/agencies.component.js
@@ -139,14 +139,14 @@ class AgenciesMain extends React.Component {
                       key={ind}
                       onClick={() => goToPage(VIEW_AGENCIES_PAGE, item._id)}
                     >
-                        <td className="blue-color">{item.name}</td>
-                        <td>{item.description}</td>
-                        <td>{item.officers || "N/A"}</td>
-                        <td>
-                          <div className={`status-icon ${status}-status-icon`}>
-                            {status}
-                          </div>
-                        </td>
+                      <td className="blue-color">{item.name}</td>
+                      <td>{item.description}</td>
+                      <td>{item.officers || "N/A"}</td>
+                      <td>
+                        <div className={`status-icon ${status}-status-icon`}>
+                          {status}
+                        </div>
+                      </td>
                       <td
                         className="blue-color"
                         onClick={(e) => {

--- a/src/components/agencies/agencies.component.js
+++ b/src/components/agencies/agencies.component.js
@@ -137,19 +137,20 @@ class AgenciesMain extends React.Component {
                     <tr
                       className="table-row row-body"
                       key={ind}
-                      onClick={() => goToPage(VIEW_AGENCIES_PAGE, item._id)}
                     >
-                      <td className="blue-color">{item.name}</td>
-                      <td>{item.description}</td>
-                      <td>{item.officers || "N/A"}</td>
-                      <td>
-                        <div className={`status-icon ${status}-status-icon`}>
-                          {status}
-                        </div>
-                      </td>
+                      <slot onClick={() => goToPage(VIEW_AGENCIES_PAGE, item._id)}>
+                        <td className="blue-color">{item.name}</td>
+                        <td>{item.description}</td>
+                        <td>{item.officers || "N/A"}</td>
+                        <td>
+                          <div className={`status-icon ${status}-status-icon`}>
+                            {status}
+                          </div>
+                        </td>
+                      </slot>
                       <td
                         className="blue-color"
-                        onClick={(e) => this.goTo(e, EDIT_AGENCIES_PAGE)}
+                        onClick={() => goToPage(EDIT_AGENCIES_PAGE, item._id)}
                       >
                         {t("BUTTONS.EDIT")}
                       </td>

--- a/src/components/agencies/agencies.component.js
+++ b/src/components/agencies/agencies.component.js
@@ -137,8 +137,8 @@ class AgenciesMain extends React.Component {
                     <tr
                       className="table-row row-body"
                       key={ind}
+                      onClick={() => goToPage(VIEW_AGENCIES_PAGE, item._id)}
                     >
-                      <slot onClick={() => goToPage(VIEW_AGENCIES_PAGE, item._id)}>
                         <td className="blue-color">{item.name}</td>
                         <td>{item.description}</td>
                         <td>{item.officers || "N/A"}</td>
@@ -147,10 +147,12 @@ class AgenciesMain extends React.Component {
                             {status}
                           </div>
                         </td>
-                      </slot>
                       <td
                         className="blue-color"
-                        onClick={() => goToPage(EDIT_AGENCIES_PAGE, item._id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          goToPage(EDIT_AGENCIES_PAGE, item._id);
+                        }}
                       >
                         {t("BUTTONS.EDIT")}
                       </td>

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -2,15 +2,11 @@ import React, { Component, Fragment } from "react";
 import { Formik, Form } from "formik";
 import { TextField } from "@material-ui/core";
 import { withTranslation } from "react-i18next";
-import Select from "@material-ui/core/Select";
-import MenuItem from "@material-ui/core/MenuItem";
-import InputLabel from "@material-ui/core/InputLabel";
-import FormControl from "@material-ui/core/FormControl";
 import history from "../../../root/root.history";
 import AgencyService from "./../../../services/agency.service";
-import { AGENCIES_PAGE } from "../../../root/root.constants";
+import Switch from "@material-ui/core/Switch";
 
-// import "./view-agency.css";
+import "./edit-agency.css";
 
 const agencyService = AgencyService.getInstance();
 
@@ -21,12 +17,27 @@ class EditAgency extends Component {
   };
 
   saveAgency = (values) => {
-    console.log(values)
-  }
+    const { agencyInfo, loading } = this.state;
+    let newAgency = {
+      active: true,
+      name: values.name,
+      description: values.description,
+      site: values.site,
+      email: values.email,
+    };
+
+    agencyService
+      .updateAgency(agencyInfo._id, newAgency)
+      .then(() => this.goRedirect())
+      .catch((error) => {
+        error.message
+        ? this.setState({ error: `${error.name}: ${error.message}` })
+        : this.setState({ error: "An unexpected error occurred!" });
+      });
+  };
 
   goRedirect() {
     history.goBack();
-    // history.push(AGENCIES_PAGE);
   }
 
   clearForm = () => {
@@ -85,7 +96,7 @@ class EditAgency extends Component {
                 <div className="item-name">{agencyInfo.name}</div>
               </div>
             </div>
-            <div className="flex-row standard-view white-bg box-shadow relative new-agency-form">
+            <div className="flex-column justify-center align-center standard-view white-bg box-shadow relative edit-agency-form">
               <Formik
                 initialValues={initialValues}
                 onSubmit={this.saveAgency}
@@ -98,26 +109,34 @@ class EditAgency extends Component {
                   setFieldValue,
                 }) => (
                   <Form onSubmit={handleSubmit}>
-                    <div className="flex-column new-agency-box">
-                      <FormControl className="form-input">
-                        <InputLabel id="role-label">
-                          {t("AGENCY_PAGE.EDIT_AGENCY.STATUS")}
-                        </InputLabel>
-                        <Select
-                          labelId="active-label"
-                          onChange={(e) =>
-                            setFieldValue("active", e.target.value === "active")
+                    <div className="flex-column edit-agency-box">
+                      <div className="status-line flex-row justify-between">
+                        <TextField
+                          label={t("AGENCY_PAGE.EDIT_AGENCY.STATUS")}
+                          name="active"
+                          className="form-input"
+                          onBlur={handleBlur}
+                          type="text"
+                          value={
+                            values.active
+                              ? t("AGENCY_PAGE.EDIT_AGENCY.ACTIVE")
+                              : t("AGENCY_PAGE.EDIT_AGENCY.INACTIVE")
                           }
-                          value={values.active ? "active" : "inactive"}
-                        >
-                          <MenuItem value="active">
-                            {t("CREATE_USER_PAGE.ACTIVE")}
-                          </MenuItem>
-                          <MenuItem value="inactive">
-                            {t("CREATE_USER_PAGE.INACTIVE")}
-                          </MenuItem>
-                        </Select>
-                      </FormControl>
+                          InputProps={{
+                            readOnly: true,
+                          }}
+                        />
+                        <Switch
+                          checked={values.active}
+                          onChange={(e) =>
+                            setFieldValue("active", e.target.checked)
+                          }
+                          color="default"
+                          name="active"
+                          className="status-switch"
+                          inputProps={{ "aria-label": "primary checkbox" }}
+                        />
+                      </div>
                       <TextField
                         label={t("AGENCY_PAGE.EDIT_AGENCY.NAME")}
                         name="name"
@@ -160,17 +179,17 @@ class EditAgency extends Component {
                       />
                     </div>
                     <div className="flex-row justify-around align-center margin-top">
-                      <button 
-                        className="blue-btn" 
-                        type="submit" 
+                      <button
+                        className="blue-btn"
+                        type="submit"
                         onClick={this.saveAgency}
-                        >
+                      >
                         {t("BUTTONS.SAVE")}
                       </button>
                       <div
                         className="blue-color pointer"
                         onClick={this.clearForm}
-                        >
+                      >
                         {t("BUTTONS.CANCEL")}
                       </div>
                     </div>

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -111,7 +111,7 @@ class EditAgency extends Component {
                 }) => (
                   <Form onSubmit={handleSubmit}>
                     <div className="flex-column edit-agency-box">
-                      <div className="status-line flex-row justify-between">
+                      <div className="active-line flex-row justify-between">
                         <TextField
                           label={t("AGENCY_PAGE.EDIT_AGENCY.STATUS")}
                           name="active"
@@ -123,14 +123,12 @@ class EditAgency extends Component {
                               ? t("AGENCY_PAGE.EDIT_AGENCY.ACTIVE")
                               : t("AGENCY_PAGE.EDIT_AGENCY.INACTIVE")
                           }
-                          InputProps={{
-                            readOnly: true,
-                          }}
+                          InputProps={{ readOnly: true }}
                         />
                         <IOSSwitch
                           checked={values.active}
                           name="active"
-                          className="status-switch"
+                          className="active-switch"
                           onChange={(e) =>
                             setFieldValue("active", e.target.checked)
                           }
@@ -144,6 +142,7 @@ class EditAgency extends Component {
                         onChange={(e) => setFieldValue("name", e.target.value)}
                         type="text"
                         value={values.name}
+                        required
                       />
                       <TextField
                         label={t("AGENCY_PAGE.EDIT_AGENCY.DESCRIPTION")}
@@ -155,26 +154,27 @@ class EditAgency extends Component {
                           setFieldValue("description", e.target.value)
                         }
                         value={values.description}
+                        required
                       />
                       <TextField
                         label={t("AGENCY_PAGE.EDIT_AGENCY.SITE")}
-                        name="email"
+                        name="site"
                         type="text"
                         className="form-input"
                         onBlur={handleBlur}
-                        onChange={(e) =>
-                          setFieldValue("website", e.target.value)
-                        }
+                        onChange={(e) => setFieldValue("site", e.target.value)}
                         value={values.site}
+                        required
                       />
                       <TextField
                         label={t("AGENCY_PAGE.EDIT_AGENCY.EMAIL")}
-                        name="site"
+                        name="email"
                         type="text"
                         className="form-input"
                         onBlur={handleBlur}
                         onChange={(e) => setFieldValue("email", e.target.value)}
                         value={values.email}
+                        required
                       />
                     </div>
                     <div className="flex-row justify-center align-center margin-top">

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -1,13 +1,188 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
+import { Formik, Form } from "formik";
+import { TextField } from "@material-ui/core";
+import { withTranslation } from "react-i18next";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import InputLabel from "@material-ui/core/InputLabel";
+import FormControl from "@material-ui/core/FormControl";
+import history from "../../../root/root.history";
+import AgencyService from "./../../../services/agency.service";
+import { AGENCIES_PAGE } from "../../../root/root.constants";
+
+// import "./view-agency.css";
+
+const agencyService = AgencyService.getInstance();
 
 class EditAgency extends Component {
+  state = {
+    agencyInfo: {},
+    loading: false,
+  };
+
+  saveAgency = (values) => {
+    console.log(values)
+  }
+
+  goRedirect() {
+    history.goBack();
+    // history.push(AGENCIES_PAGE);
+  }
+
+  clearForm = () => {
+    this.goRedirect();
+  };
+
+  componentDidMount() {
+    const { id } = this.props.match.params;
+
+    this.setState({ loading: true }, () => {
+      agencyService
+        .getAgency(id)
+        .then((data) => {
+          const agencyInfo = { ...data, ...this.state.agencyInfo };
+
+          this.setState({
+            agencyInfo,
+            loading: false,
+          });
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    });
+  }
+
   render() {
+    const { agencyInfo, loading } = this.state;
+    const { t } = this.props;
+
+    const initialValues = !loading
+      ? {
+          active: true,
+          name: agencyInfo.name,
+          description: agencyInfo.description,
+          site: agencyInfo.site,
+          email: agencyInfo.email,
+        }
+      : {
+          active: true,
+          name: "",
+          description: "",
+          site: "",
+          email: "",
+        };
+
     return (
-      <div className="edit-agency-page">
-        Edit Agency page
+      <div className="flex-column align-center padding-top">
+        {loading ? (
+          t("LOADING.LOADING")
+        ) : (
+          <Fragment>
+            <div className="flex-row justify-between standard-view">
+              <div>
+                <div className="item-label">{t("TABLE.AGENCY")}</div>
+                <div className="item-name">{agencyInfo.name}</div>
+              </div>
+            </div>
+            <div className="flex-row standard-view white-bg box-shadow relative new-agency-form">
+              <Formik
+                initialValues={initialValues}
+                onSubmit={this.saveAgency}
+                render={({
+                  errors,
+                  values,
+                  handleChange,
+                  handleBlur,
+                  handleSubmit,
+                  setFieldValue,
+                }) => (
+                  <Form onSubmit={handleSubmit}>
+                    <div className="flex-column new-agency-box">
+                      <FormControl className="form-input">
+                        <InputLabel id="role-label">
+                          {t("AGENCY_PAGE.EDIT_AGENCY.STATUS")}
+                        </InputLabel>
+                        <Select
+                          labelId="active-label"
+                          onChange={(e) =>
+                            setFieldValue("active", e.target.value === "active")
+                          }
+                          value={values.active ? "active" : "inactive"}
+                        >
+                          <MenuItem value="active">
+                            {t("CREATE_USER_PAGE.ACTIVE")}
+                          </MenuItem>
+                          <MenuItem value="inactive">
+                            {t("CREATE_USER_PAGE.INACTIVE")}
+                          </MenuItem>
+                        </Select>
+                      </FormControl>
+                      <TextField
+                        label={t("AGENCY_PAGE.EDIT_AGENCY.NAME")}
+                        name="name"
+                        className="form-input"
+                        onBlur={handleBlur}
+                        onChange={(e) => setFieldValue("name", e.target.value)}
+                        type="text"
+                        value={values.name}
+                      />
+                      <TextField
+                        label={t("AGENCY_PAGE.EDIT_AGENCY.DESCRIPTION")}
+                        name="description"
+                        type="text"
+                        className="form-input"
+                        onBlur={handleBlur}
+                        onChange={(e) =>
+                          setFieldValue("description", e.target.value)
+                        }
+                        value={values.description}
+                      />
+                      <TextField
+                        label={t("AGENCY_PAGE.EDIT_AGENCY.SITE")}
+                        name="email"
+                        type="text"
+                        className="form-input"
+                        onBlur={handleBlur}
+                        onChange={(e) =>
+                          setFieldValue("website", e.target.value)
+                        }
+                        value={values.site}
+                      />
+                      <TextField
+                        label={t("AGENCY_PAGE.EDIT_AGENCY.EMAIL")}
+                        name="site"
+                        type="text"
+                        className="form-input"
+                        onBlur={handleBlur}
+                        onChange={(e) => setFieldValue("email", e.target.value)}
+                        value={values.email}
+                      />
+                    </div>
+                    <div className="flex-row justify-around align-center margin-top">
+                      <button 
+                        className="blue-btn" 
+                        type="submit" 
+                        onClick={this.saveAgency}
+                        >
+                        {t("BUTTONS.SAVE")}
+                      </button>
+                      <div
+                        className="blue-color pointer"
+                        onClick={this.clearForm}
+                        >
+                        {t("BUTTONS.CANCEL")}
+                      </div>
+                    </div>
+                  </Form>
+                )}
+              />
+            </div>
+          </Fragment>
+        )}
       </div>
     );
   }
 }
 
-export default EditAgency;
+export default withTranslation("translation")(EditAgency);

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -27,6 +27,8 @@ class EditAgency extends Component {
       email: values.email,
     };
 
+    console.log(newAgency)
+
     agencyService
       .updateAgency(agencyInfo._id, newAgency)
       .then(() => this.goRedirect())
@@ -181,7 +183,6 @@ class EditAgency extends Component {
                       <button
                         className="blue-btn"
                         type="submit"
-                        onClick={this.saveAgency}
                       >
                         {t("BUTTONS.SAVE")}
                       </button>

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -19,7 +19,7 @@ class EditAgency extends Component {
   saveAgency = (values) => {
     const { agencyInfo, loading } = this.state;
     let newAgency = {
-      active: true,
+      active: values.active,
       name: values.name,
       description: values.description,
       site: values.site,
@@ -31,8 +31,8 @@ class EditAgency extends Component {
       .then(() => this.goRedirect())
       .catch((error) => {
         error.message
-        ? this.setState({ error: `${error.name}: ${error.message}` })
-        : this.setState({ error: "An unexpected error occurred!" });
+          ? this.setState({ error: `${error.name}: ${error.message}` })
+          : this.setState({ error: "An unexpected error occurred!" });
       });
   };
 
@@ -70,14 +70,14 @@ class EditAgency extends Component {
 
     const initialValues = !loading
       ? {
-          active: true,
+          active: agencyInfo.active,
           name: agencyInfo.name,
           description: agencyInfo.description,
           site: agencyInfo.site,
           email: agencyInfo.email,
         }
       : {
-          active: true,
+          active: false,
           name: "",
           description: "",
           site: "",

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -27,8 +27,6 @@ class EditAgency extends Component {
       email: values.email,
     };
 
-    console.log(newAgency)
-
     agencyService
       .updateAgency(agencyInfo._id, newAgency)
       .then(() => this.goRedirect())

--- a/src/components/agencies/edit-agency/edit-agency.component.js
+++ b/src/components/agencies/edit-agency/edit-agency.component.js
@@ -4,7 +4,8 @@ import { TextField } from "@material-ui/core";
 import { withTranslation } from "react-i18next";
 import history from "../../../root/root.history";
 import AgencyService from "./../../../services/agency.service";
-import Switch from "@material-ui/core/Switch";
+
+import IOSSwitch from "../../partials/ios-switch/ios-switch";
 
 import "./edit-agency.css";
 
@@ -126,15 +127,13 @@ class EditAgency extends Component {
                             readOnly: true,
                           }}
                         />
-                        <Switch
+                        <IOSSwitch
                           checked={values.active}
+                          name="active"
+                          className="status-switch"
                           onChange={(e) =>
                             setFieldValue("active", e.target.checked)
                           }
-                          color="default"
-                          name="active"
-                          className="status-switch"
-                          inputProps={{ "aria-label": "primary checkbox" }}
                         />
                       </div>
                       <TextField
@@ -178,7 +177,7 @@ class EditAgency extends Component {
                         value={values.email}
                       />
                     </div>
-                    <div className="flex-row justify-around align-center margin-top">
+                    <div className="flex-row justify-center align-center margin-top">
                       <button
                         className="blue-btn"
                         type="submit"

--- a/src/components/agencies/edit-agency/edit-agency.css
+++ b/src/components/agencies/edit-agency/edit-agency.css
@@ -7,12 +7,7 @@
 .edit-agency-form .blue-btn {
     top: -75px;
     right: 65px;
-}
-
-.edit-agency-form .white-btn {
-    top: -75px;
-    right: 0px;
-    padding: 9px;
+    padding: 10px 24px;
 }
 
 .edit-agency-box .form-input {
@@ -24,21 +19,17 @@
     margin-top: 0;
 }
 
-.edit-agency-form .status-line {
+.edit-agency-form .active-line {
     position: relative;
 }
 
-.edit-agency-form .status-line .form-input {
+.edit-agency-form .active-line .form-input {
     width: 100%;
 }
 
-.edit-agency-form .status-line .status-switch {
+.edit-agency-form .active-line .active-switch {
     position: absolute;
     right: 0;
     margin: 0;
     margin-top: 4px;
-}
-
-.edit-agency-form .blue-btn {
-    padding: 10px 24px;
 }

--- a/src/components/agencies/edit-agency/edit-agency.css
+++ b/src/components/agencies/edit-agency/edit-agency.css
@@ -38,3 +38,7 @@
     margin: 0;
     margin-top: 4px;
 }
+
+.edit-agency-form .blue-btn {
+    padding: 10px 24px;
+}

--- a/src/components/agencies/edit-agency/edit-agency.css
+++ b/src/components/agencies/edit-agency/edit-agency.css
@@ -1,0 +1,40 @@
+.edit-agency-form {
+    margin: 20px 0;
+    padding-top: 60px;
+    padding-bottom: 60px;
+}
+
+.edit-agency-form .blue-btn {
+    top: -75px;
+    right: 65px;
+}
+
+.edit-agency-form .white-btn {
+    top: -75px;
+    right: 0px;
+    padding: 9px;
+}
+
+.edit-agency-box .form-input {
+    width: 350px;
+    margin-top: 30px;
+}
+
+.edit-agency-box .form-input:first-child {
+    margin-top: 0;
+}
+
+.edit-agency-form .status-line {
+    position: relative;
+}
+
+.edit-agency-form .status-line .form-input {
+    width: 100%;
+}
+
+.edit-agency-form .status-line .status-switch {
+    position: absolute;
+    right: 0;
+    margin: 0;
+    margin-top: 4px;
+}

--- a/src/components/agencies/view-agency/view-agency.component.js
+++ b/src/components/agencies/view-agency/view-agency.component.js
@@ -4,8 +4,6 @@ import { withTranslation } from "react-i18next";
 
 import { EDIT_AGENCIES_PAGE } from "./../../../root/root.constants";
 
-import { goToPage } from "./../../../helpers/get-data";
-
 import AgencyService from "./../../../services/agency.service";
 import AgencyFormData from "../form-data/form-data.js"
 

--- a/src/components/agencies/view-agency/view-agency.component.js
+++ b/src/components/agencies/view-agency/view-agency.component.js
@@ -4,6 +4,8 @@ import { withTranslation } from "react-i18next";
 
 import { EDIT_AGENCIES_PAGE } from "./../../../root/root.constants";
 
+import { goToPage } from "./../../../helpers/get-data";
+
 import AgencyService from "./../../../services/agency.service";
 import AgencyFormData from "../form-data/form-data.js"
 
@@ -86,7 +88,7 @@ class ViewAgency extends Component {
               </Fragment>
             )}
           </div>
-          <NavLink to={EDIT_AGENCIES_PAGE}>
+          <NavLink to={EDIT_AGENCIES_PAGE.replace(":id", agencyInfo._id)}>
             <button className="blue-btn">{t("BUTTONS.EDIT_AGENCY")}</button>
           </NavLink>
         </div>

--- a/src/components/partials/ios-switch/ios-switch.js
+++ b/src/components/partials/ios-switch/ios-switch.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { withStyles } from "@material-ui/core/styles";
+import Switch from "@material-ui/core/Switch";
+
+const IOSSwitch = withStyles((theme) => ({
+  root: {
+    width: 42,
+    height: 26,
+    padding: 0,
+    margin: theme.spacing(1),
+  },
+  switchBase: {
+    padding: 1,
+    "&$checked": {
+      transform: "translateX(16px)",
+      color: theme.palette.common.white,
+      "& + $track": {
+        backgroundColor: "#52d869",
+        opacity: 1,
+        border: "none",
+      },
+    },
+    "&$focusVisible $thumb": {
+      color: "#52d869",
+      border: "6px solid #fff",
+    },
+  },
+  thumb: {
+    width: 24,
+    height: 24,
+  },
+  track: {
+    borderRadius: 26 / 2,
+    backgroundColor: "#e9e9ea",
+    opacity: 1,
+    transition: theme.transitions.create(["background-color", "border"]),
+  },
+  checked: {},
+  focusVisible: {},
+}))(({ classes, ...props }) => {
+  return (
+    <Switch
+      focusVisibleClassName={classes.focusVisible}
+      disableRipple
+      classes={{
+        root: classes.root,
+        switchBase: classes.switchBase,
+        thumb: classes.thumb,
+        track: classes.track,
+        checked: classes.checked,
+      }}
+      {...props}
+    />
+  );
+});
+
+export default IOSSwitch;

--- a/src/helpers/i18n/en/translation.json
+++ b/src/helpers/i18n/en/translation.json
@@ -83,7 +83,16 @@
   },
   "AGENCY_PAGE": {
     "FORM_DATA": "Form Data",
-    "PREFERED_NATIONALITIES": "Prefered Nationatities"
+    "PREFERED_NATIONALITIES": "Prefered Nationatities",
+    "EDIT_AGENCY": {
+      "STATUS": "Status",
+      "ACTIVE": "Active",
+      "INACTIVE": "Inactive",
+      "NAME": "Agency Name",
+      "DESCRIPTION": "Description",
+      "SITE": "Website",
+      "EMAIL": "Contact Email"
+    }
   },
   "USERS_PAGE": {
     "SEE_ACTIVITY": "See Activity"

--- a/src/root/root.constants.js
+++ b/src/root/root.constants.js
@@ -36,5 +36,5 @@ export const VIEW_USER_PAGE = "/users/view_user";
 
 //Agencies subroutes
 export const NEW_AGENCIES_PAGE = "/agencies/new_agency";
-export const EDIT_AGENCIES_PAGE = "/agencies/edit_agency/";
+export const EDIT_AGENCIES_PAGE = "/agencies/edit_agency/:id";
 export const VIEW_AGENCIES_PAGE = "/agencies/view_agency/:id";

--- a/src/services/agency.service.js
+++ b/src/services/agency.service.js
@@ -32,4 +32,11 @@ export default class AgencyService {
   createAgency(data) {
     return stitchService.database.collection("Agency").insertOne(data);
   }
+
+  updateAgency(id, data) {
+    id = new BSON.ObjectId(id);
+    return stitchService.database.collection("Agency").updateOne({
+      _id: id
+    }, data);
+  }
 }


### PR DESCRIPTION
Fixes #178 

### Requirements

- [x] fields get saved to the `Agency` collection
  - [x] status saves as a Boolean to `active`
  - [x] name gets saved as `name`
  - [x] description gets saved as `description`
  - [x] website gets saved as `site`
  - [x] contact email gets saved as `email`
- [x] can access via the "Edit" button on each row in the Agencies page
- [x] can access via the "Edit Agency" button when viewing a specific agency

### Changes made
* implemented the Edit Agency page
* created a new service function `updateAgency`
* added an `id` parameter to the `EDIT_AGENCIES_PAGE` route
* added a new partial component `IOSSwitch` that styles the Material UI switch (code snippet from [Material UI docs](https://material-ui.com/components/switches/#customized-switches))

### Screenshot
<img width="1535" alt="Screen Shot 2020-09-06 at 1 41 12 PM" src="https://user-images.githubusercontent.com/37346399/92331710-a41d9300-f046-11ea-908f-c9d3365c0df3.png">
