### PR TITLE
Violations boarded on date bugfix

### DIFF
--- a/src/components/partials/overview-pages/violations-overview/violations-overview.component.js
+++ b/src/components/partials/overview-pages/violations-overview/violations-overview.component.js
@@ -44,7 +44,7 @@ const ViolationsOverview = ({ t, filter, violations }) => (
                 </td>
                 <td>{violation.result}</td>
                 <td>{violation.issuedBy}</td>
-                <td>{moment(violation.boarding).format("L")}</td>
+                <td>{moment(violation.boardingDate).format("L")}</td>
                 <td
                   onClick={() =>
                     goToPage(VIEW_BOARDING_PAGE, violation.boardingId)

--- a/src/components/violations/violations.component.js
+++ b/src/components/violations/violations.component.js
@@ -179,7 +179,7 @@ class ViolationsPage extends Component {
                       <td>{violation.result}</td>
                       <td>{violation.issuedBy}</td>
                       <td>{violation.vessel}</td>
-                      <td>{moment(violation.boarding).format("L")}</td>
+                      <td>{moment(violation.boardingDate).format("L")}</td>
                       <td>
                         <RiskIcon safetyLevel={violation.risk} />
                       </td>


### PR DESCRIPTION
Fixes #183 

### Changes made
* updated `violations-overview.component.js` and `violations.component.js` to reference correct attribute name

### Screenshots

**`/violations` page** 

<img width="1380" alt="Screen Shot 2020-09-09 at 4 01 51 PM" src="https://user-images.githubusercontent.com/37346399/92647599-22cc3780-f2b6-11ea-95cf-9e0862b23b5b.png">

**`/vessels/view` page**

<img width="1536" alt="Screen Shot 2020-09-09 at 4 01 37 PM" src="https://user-images.githubusercontent.com/37346399/92647604-2495fb00-f2b6-11ea-9cd1-81ab5abeb291.png">

