### PR TITLE
Fixes #248

### DIFF
--- a/src/components/users/new-dev-user/new-dev-user.component.js
+++ b/src/components/users/new-dev-user/new-dev-user.component.js
@@ -185,6 +185,7 @@ class NewDevUser extends Component {
                     }
                     value={values.agencyName}
                     required
+                    helperText="Must be unique; we recommend using your github username"
                   />
                   <TextField
                     label={t("AGENCY_PAGE.EDIT_AGENCY.SITE")}
@@ -196,6 +197,7 @@ class NewDevUser extends Component {
                     }
                     value={values.agencySite}
                     required
+                    helperText="Required; does not have to be a website. Can use any string including Twitter handle"
                   />
                 </div>
                 <div className="flex-row justify-around align-center margin-top">


### PR DESCRIPTION
Adds helper text to suggest github username for the agency name (to be unique) and clarifies that website can be any text.

Updated page looks like this:

![Screen Shot 2020-09-30 at 10 25 14 AM](https://user-images.githubusercontent.com/1767528/94698363-3bed6480-0307-11eb-93d2-229f56b2eeff.png)
