### PR TITLE
Fix missing i10n text at vessel view

### DIFF
--- a/src/components/vessels/vessel-view/vessel-view.component.js
+++ b/src/components/vessels/vessel-view/vessel-view.component.js
@@ -105,21 +105,21 @@ class VesselViewPage extends Component {
             </div>
             <div className="flex-row justify-between standard-view">
               <VesselHeaderInfo
-                headerText="Permit Number"
+                headerText={t("TABLE.PERMIT_NUMBER")}
                 data={permitNumbers[0] || ""}
               />
               <VesselHeaderInfo
-                headerText="Flag States"
+                headerText={t("TABLE.FLAG_STATES")}
                 data={nationalities[0] || ""}
                 itemsAmount={nationalities.length}
               />
               <VesselHeaderInfo
-                headerText="Home Ports"
+                headerText={t("TABLE.HOME_PORTS")}
                 data={homePorts[0] || ""}
                 itemsAmount={homePorts.length}
               />
               <VesselHeaderInfo
-                headerText="Captains"
+                headerText={t("TABLE.CAPTAINS")}
                 data={captains[0] ? captains[0].name : ""}
                 itemsAmount={captains.length}
               />

--- a/src/helpers/i18n/en/translation.json
+++ b/src/helpers/i18n/en/translation.json
@@ -195,7 +195,10 @@
     "DELIVERIES": "Deliveries",
     "ISSUED_TO": "Issued To",
     "CREW_MEMBER": "Crew Member",
-    "PHOTO": "Photo"
+    "PHOTO": "Photo",
+    "FLAG_STATES": "Flag States",
+    "HOME_PORTS": "Home Ports",
+    "CAPTAINS": "Captains"
   },
   "FILTER": {
     "FROM": "From",

--- a/src/helpers/i18n/fr/translation.json
+++ b/src/helpers/i18n/fr/translation.json
@@ -194,7 +194,10 @@
     "DELIVERIES": "Livraisons",
     "ISSUED_TO": "Remis à",
     "CREW_MEMBER": "Membre d'Equipage",
-    "PHOTO": "Photo"
+    "PHOTO": "Photo",
+    "FLAG_STATES": "États du Pavillon",
+    "HOME_PORTS": "Ports d'Origine",
+    "CAPTAINS": "Capitaines"
   },
   "FILTER": {
     "FROM": "A partir de",


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes https://github.com/WildAid/o-fish-web/issues/262

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

At the issue, missing translation key are stated as:

- PERMIT_NUMBERS
- FLAG_STATES
- HOME_PORTS
- CAPTAINS

However, when I've check the code, I've notice that `PERMIT_NUMBERS` usage is not plural. It is "Permit Number" and the file already has this key:

https://github.com/WildAid/o-fish-web/blob/5a4fe430be0a76b44833cd5dae512e9e477395d6/src/helpers/i18n/en/translation.json#L174

https://github.com/WildAid/o-fish-web/blob/5a4fe430be0a76b44833cd5dae512e9e477395d6/src/helpers/i18n/fr/translation.json#L173

So other three is added for both `en` and `fr` and vessel-view is update to use this new keys.



