### PR TITLE
Fix crew member page showing duplicate vessel names

### DIFF
--- a/src/components/crew/crew.component.js
+++ b/src/components/crew/crew.component.js
@@ -355,7 +355,7 @@ class Crew extends Component {
                           textToHighlight={item.license}
                         />
                       </td>
-                      <td>{item.vessels.slice(0, 4).join(", ")}</td>
+                      <td>{[...new Set(item.vessels)].slice(0, 4).join(",")}</td>
                       <td>
                         {item && item.violations ? item.violations : "N/A"}
                       </td>


### PR DESCRIPTION
## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes https://github.com/WildAid/o-fish-web/issues/237

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

I think this one was straight forward, so there is nothing more to add.

Feel free to ask any changes if needed 🙏 
