### PR TITLE
change Role and Group select input to read-only text field in Account Profile

### DIFF
--- a/src/components/partials/user-editor/user-editor.component.js
+++ b/src/components/partials/user-editor/user-editor.component.js
@@ -229,7 +229,8 @@ class UserEditor extends Component {
           userGroup: "",
         };
 
-    const isAgencyOrGlobal = ["agency", "global"].includes(authService.userRole);
+    const isAgencyAdmin = authService.userRole === "agency"
+    const isGlobalAdmin = authService.userRole === "global"
 
     return (
       <div className="flex-column align-center standard-view white-bg box-shadow relative user-editor-form">
@@ -353,7 +354,7 @@ class UserEditor extends Component {
                 {showingOptions.role && (
                   <Fragment>
                     {
-                      isAgencyOrGlobal ? (
+                      (isAgencyAdmin || isGlobalAdmin) ? (
                         <React.Fragment>
                           <FormControl className="form-input">
                             <InputLabel id="role-label">
@@ -393,7 +394,7 @@ class UserEditor extends Component {
                           </FormControl>
                           <div className="error-messages">{t(errors.adminType)}</div>
                         </React.Fragment>
-                      ) :(
+                      ) : (
                         <TextField
                           label={t("CREATE_USER_PAGE.ROLE")}
                           name="adminType"
@@ -410,7 +411,7 @@ class UserEditor extends Component {
                       )
                     }
                     {
-                      isAgencyOrGlobal ? (
+                      isGlobalAdmin ? (
                         <FormControl className="form-input">
                           <InputLabel id="agency-label">
                             {t("TABLE.AGENCY")}
@@ -455,7 +456,7 @@ class UserEditor extends Component {
                       />)
                     }
                     {
-                      isAgencyOrGlobal ? (
+                      (isAgencyAdmin || isGlobalAdmin) ? (
                         <FormControl className="form-input">
                           <InputLabel id="group-label">
                             {t("CREATE_USER_PAGE.USER_GROUP")}

--- a/src/components/partials/user-editor/user-editor.component.js
+++ b/src/components/partials/user-editor/user-editor.component.js
@@ -229,8 +229,8 @@ class UserEditor extends Component {
           userGroup: "",
         };
 
-    const isAgencyAdmin = authService.userRole === "agency"
-    const isGlobalAdmin = authService.userRole === "global"
+    const isAgencyAdmin = authService.userRole === "agency";
+    const isGlobalAdmin = authService.userRole === "global";
 
     return (
       <div className="flex-column align-center standard-view white-bg box-shadow relative user-editor-form">

--- a/src/components/partials/user-editor/user-editor.component.js
+++ b/src/components/partials/user-editor/user-editor.component.js
@@ -193,6 +193,13 @@ class UserEditor extends Component {
     if (!showingOptions) showingOptions = {};
     if (!showingOptions.saveText) showingOptions.saveText = t("BUTTONS.SAVE");
 
+    const hashAdminTypeToRoleName =  {
+      global: t("ADMINS.GLOBAL"),
+      agency:  t("ADMINS.AGENCY"),
+      group: t("ADMINS.GROUP"),
+      field: t("ADMINS.FIELD"),
+    }
+
     const initialValues = user
       ? {
           profilePic: user.profilePic,
@@ -350,40 +357,25 @@ class UserEditor extends Component {
                       onBlur={handleBlur}
                       onChange={(e) => setFieldValue("adminType", e.target.value)}
                       type="text"
-                      value={values.adminType}
+                      value={hashAdminTypeToRoleName[values.adminType]}
                       InputProps={{
                         readOnly: true,
                         disableUnderline: true,
                       }}
                     />
-                    <FormControl className="form-input">
-                      <InputLabel id="agency-label">
-                        {t("TABLE.AGENCY")}
-                      </InputLabel>
-                      <Select
-                        readOnly={!!showingOptions.readOnly}
-                        labelId="agency-label"
-                        onChange={(e) =>
-                          setFieldValue("agency", e.target.value)
-                        }
-                        value={values.agency}
-                      >
-                        {authService.userRole === "global" ? (
-                          agencies.map((agency, ind) => (
-                            <MenuItem value={agency} key={ind}>
-                              <em>{agency}</em>
-                            </MenuItem>
-                          ))
-                        ) : (
-                          <MenuItem
-                            value={authService.user.agency.name}
-                            key={0}
-                          >
-                            <em>{authService.user.agency.name}</em>
-                          </MenuItem>
-                        )}
-                      </Select>
-                    </FormControl>
+                    <TextField
+                      label={t("TABLE.AGENCY")}
+                      name="agency"
+                      className="form-input"
+                      onBlur={handleBlur}
+                      onChange={(e) => setFieldValue("agency", e.target.value)}
+                      type="text"
+                      value={values.agency}
+                      InputProps={{
+                        readOnly: true,
+                        disableUnderline: true,
+                      }}
+                    />
                     <TextField
                       label={t("CREATE_USER_PAGE.USER_GROUP")}
                       name="userGroup"

--- a/src/components/partials/user-editor/user-editor.component.js
+++ b/src/components/partials/user-editor/user-editor.component.js
@@ -343,43 +343,19 @@ class UserEditor extends Component {
                 )}
                 {showingOptions.role && (
                   <Fragment>
-                    <FormControl className="form-input">
-                      <InputLabel id="role-label">
-                        {t("CREATE_USER_PAGE.ROLE")}
-                      </InputLabel>
-                      <Select
-                        readOnly={!!showingOptions.readOnly}
-                        labelId="role-label"
-                        onChange={(e) => {
-                          this.setState({ disabled: isValid });
-                          setFieldValue("adminType", e.target.value);
-                        }}
-                        value={values.adminType}
-                      >
-                        {authService.userRole === "global" ? (
-                          <MenuItem value="global">
-                            <em>{t("ADMINS.GLOBAL")}</em>
-                          </MenuItem>
-                        ) : (
-                          ""
-                        )}
-                        {authService.userRole === "global" ||
-                        authService.userRole === "agency" ? (
-                          <MenuItem value="agency">
-                            <em>{t("ADMINS.AGENCY")}</em>
-                          </MenuItem>
-                        ) : (
-                          ""
-                        )}
-                        <MenuItem value="group">
-                          <em>{t("ADMINS.GROUP")}</em>
-                        </MenuItem>
-                        <MenuItem value="field">
-                          <em>{t("ADMINS.FIELD")}</em>
-                        </MenuItem>
-                      </Select>
-                    </FormControl>
-                    <div className="error-messages">{t(errors.adminType)}</div>
+                    <TextField
+                      label={t("CREATE_USER_PAGE.ROLE")}
+                      name="adminType"
+                      className="form-input"
+                      onBlur={handleBlur}
+                      onChange={(e) => setFieldValue("adminType", e.target.value)}
+                      type="text"
+                      value={values.adminType}
+                      InputProps={{
+                        readOnly: true,
+                        disableUnderline: true,
+                      }}
+                    />
                     <FormControl className="form-input">
                       <InputLabel id="agency-label">
                         {t("TABLE.AGENCY")}
@@ -408,23 +384,19 @@ class UserEditor extends Component {
                         )}
                       </Select>
                     </FormControl>
-                    <FormControl className="form-input">
-                      <InputLabel id="group-label">
-                        {t("CREATE_USER_PAGE.USER_GROUP")}
-                      </InputLabel>
-                      <Select
-                        readOnly={!!showingOptions.readOnly}
-                        labelId="group-label"
-                        onChange={(e) =>
-                          setFieldValue("userGroup", e.target.value)
-                        }
-                        value={values.userGroup}
-                      >
-                        <MenuItem value="User Group">
-                          <em>{t("CREATE_USER_PAGE.USER_GROUP")}</em>
-                        </MenuItem>
-                      </Select>
-                    </FormControl>
+                    <TextField
+                      label={t("CREATE_USER_PAGE.USER_GROUP")}
+                      name="userGroup"
+                      className="form-input"
+                      onBlur={handleBlur}
+                      onChange={(e) => setFieldValue("userGroup", e.target.value)}
+                      type="text"
+                      value={values.userGroup}
+                      InputProps={{
+                        readOnly: true,
+                        disableUnderline: true,
+                      }}
+                    />
                   </Fragment>
                 )}
                 <div className="flex-row justify-around align-center margin-top">

--- a/src/components/partials/user-editor/user-editor.component.js
+++ b/src/components/partials/user-editor/user-editor.component.js
@@ -229,6 +229,8 @@ class UserEditor extends Component {
           userGroup: "",
         };
 
+    const isAgencyOrGlobal = ["agency", "global"].includes(authService.userRole);
+
     return (
       <div className="flex-column align-center standard-view white-bg box-shadow relative user-editor-form">
         {!isLoaded ? (
@@ -350,45 +352,143 @@ class UserEditor extends Component {
                 )}
                 {showingOptions.role && (
                   <Fragment>
-                    <TextField
-                      label={t("CREATE_USER_PAGE.ROLE")}
-                      name="adminType"
-                      className="form-input"
-                      onBlur={handleBlur}
-                      onChange={(e) => setFieldValue("adminType", e.target.value)}
-                      type="text"
-                      value={hashAdminTypeToRoleName[values.adminType]}
-                      InputProps={{
-                        readOnly: true,
-                        disableUnderline: true,
-                      }}
-                    />
-                    <TextField
-                      label={t("TABLE.AGENCY")}
-                      name="agency"
-                      className="form-input"
-                      onBlur={handleBlur}
-                      onChange={(e) => setFieldValue("agency", e.target.value)}
-                      type="text"
-                      value={values.agency}
-                      InputProps={{
-                        readOnly: true,
-                        disableUnderline: true,
-                      }}
-                    />
-                    <TextField
-                      label={t("CREATE_USER_PAGE.USER_GROUP")}
-                      name="userGroup"
-                      className="form-input"
-                      onBlur={handleBlur}
-                      onChange={(e) => setFieldValue("userGroup", e.target.value)}
-                      type="text"
-                      value={values.userGroup}
-                      InputProps={{
-                        readOnly: true,
-                        disableUnderline: true,
-                      }}
-                    />
+                    {
+                      isAgencyOrGlobal ? (
+                        <React.Fragment>
+                          <FormControl className="form-input">
+                            <InputLabel id="role-label">
+                              {t("CREATE_USER_PAGE.ROLE")}
+                            </InputLabel>
+                            <Select
+                              readOnly={!!showingOptions.readOnly}
+                              labelId="role-label"
+                              onChange={(e) => {
+                                this.setState({ disabled: isValid });
+                                setFieldValue("adminType", e.target.value);
+                              }}
+                              value={values.adminType}
+                            >
+                              {authService.userRole === "global" ? (
+                                <MenuItem value="global">
+                                  <em>{t("ADMINS.GLOBAL")}</em>
+                                </MenuItem>
+                              ) : (
+                                ""
+                              )}
+                              {authService.userRole === "global" ||
+                              authService.userRole === "agency" ? (
+                                <MenuItem value="agency">
+                                  <em>{t("ADMINS.AGENCY")}</em>
+                                </MenuItem>
+                              ) : (
+                                ""
+                              )}
+                              <MenuItem value="group">
+                                <em>{t("ADMINS.GROUP")}</em>
+                              </MenuItem>
+                              <MenuItem value="field">
+                                <em>{t("ADMINS.FIELD")}</em>
+                              </MenuItem>
+                            </Select>
+                          </FormControl>
+                          <div className="error-messages">{t(errors.adminType)}</div>
+                        </React.Fragment>
+                      ) :(
+                        <TextField
+                          label={t("CREATE_USER_PAGE.ROLE")}
+                          name="adminType"
+                          className="form-input"
+                          onBlur={handleBlur}
+                          onChange={(e) => setFieldValue("adminType", e.target.value)}
+                          type="text"
+                          value={hashAdminTypeToRoleName[values.adminType]}
+                          InputProps={{
+                            readOnly: true,
+                            disableUnderline: true,
+                          }}
+                        />
+                      )
+                    }
+                    {
+                      isAgencyOrGlobal ? (
+                        <FormControl className="form-input">
+                          <InputLabel id="agency-label">
+                            {t("TABLE.AGENCY")}
+                          </InputLabel>
+                          <Select
+                            readOnly={!!showingOptions.readOnly}
+                            labelId="agency-label"
+                            onChange={(e) =>
+                              setFieldValue("agency", e.target.value)
+                            }
+                            value={values.agency}
+                          >
+                            {authService.userRole === "global" ? (
+                              agencies.map((agency, ind) => (
+                                <MenuItem value={agency} key={ind}>
+                                  <em>{agency}</em>
+                                </MenuItem>
+                              ))
+                            ) : (
+                              <MenuItem
+                                value={authService.user.agency.name}
+                                key={0}
+                              >
+                                <em>{authService.user.agency.name}</em>
+                              </MenuItem>
+                            )}
+                          </Select>
+                        </FormControl>
+                      ) : (                    
+                      <TextField
+                        label={t("TABLE.AGENCY")}
+                        name="agency"
+                        className="form-input"
+                        onBlur={handleBlur}
+                        onChange={(e) => setFieldValue("agency", e.target.value)}
+                        type="text"
+                        value={values.agency}
+                        InputProps={{
+                          readOnly: true,
+                          disableUnderline: true,
+                        }}
+                      />)
+                    }
+                    {
+                      isAgencyOrGlobal ? (
+                        <FormControl className="form-input">
+                          <InputLabel id="group-label">
+                            {t("CREATE_USER_PAGE.USER_GROUP")}
+                          </InputLabel>
+                          <Select
+                            readOnly={!!showingOptions.readOnly}
+                            labelId="group-label"
+                            onChange={(e) =>
+                              setFieldValue("userGroup", e.target.value)
+                            }
+                            value={values.userGroup}
+                          >
+                            <MenuItem value="User Group">
+                              <em>{t("CREATE_USER_PAGE.USER_GROUP")}</em>
+                            </MenuItem>
+                          </Select>
+                        </FormControl>
+                      ) : (
+                        <TextField
+                          label={t("CREATE_USER_PAGE.USER_GROUP")}
+                          name="userGroup"
+                          className="form-input"
+                          onBlur={handleBlur}
+                          onChange={(e) => setFieldValue("userGroup", e.target.value)}
+                          type="text"
+                          value={values.userGroup}
+                          InputProps={{
+                            readOnly: true,
+                            disableUnderline: true,
+                          }}
+                        />
+                      )
+                    }
                   </Fragment>
                 )}
                 <div className="flex-row justify-around align-center margin-top">


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #210

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 

- replaced the `<Select />` inputs for Role and Group with `<TextInput />`
- used `readOnly` and `disableUnderline` props from [Material UI Input API](https://material-ui.com/api/input/#main-content)
to make it closer to the design

* **Optional: Add any relevant screenshots here** 
Before:
![image](https://user-images.githubusercontent.com/14609656/95928918-97e8cc00-0d90-11eb-8f23-a206b760fff7.png)

After:
![image](https://user-images.githubusercontent.com/14609656/95928709-15f8a300-0d90-11eb-8d93-8a56148e494f.png)


