### PR TITLE
Use name where licence number isn't present

### DIFF
--- a/src/components/crew/crew-view/crew-view.component.js
+++ b/src/components/crew/crew-view/crew-view.component.js
@@ -51,12 +51,14 @@ class CrewViewPage extends Component {
 
   componentDidMount() {
     const filter = JSON.parse(this.props.match.params.filter);
-    const isCaptain =  filter["captain.license"] !== undefined;
-    let licenseNumber;
+    const isCaptain =  filter["captain.license"] !== undefined || filter["captain.name"] !== undefined;
+    let licenseNumber, captainName, crewName;
     if (isCaptain){
       licenseNumber = filter["captain.license"]
+      captainName = filter["captain.name"]
     } else {
       licenseNumber = filter["crew.license"];
+      crewName = filter["crew.name"]
     }
     this.setState({ loading: true }, () => {
       overviewService
@@ -73,8 +75,8 @@ class CrewViewPage extends Component {
             notes: dataHelper.getNotes(licenseNumber),
             captainName: dataHelper.getCaptainName(licenseNumber),
             crewName: isCaptain ?
-              dataHelper.getCaptainName(licenseNumber):
-              dataHelper.getCrewName(licenseNumber),
+              dataHelper.getCaptainName(licenseNumber || captainName):
+              dataHelper.getCrewName(licenseNumber || crewName),
             photos: dataHelper.getPhotos(licenseNumber),
           };
 

--- a/src/components/partials/boarding-data.helper.js
+++ b/src/components/partials/boarding-data.helper.js
@@ -188,12 +188,12 @@ export default class BoardingDataHelper {
     return Object.keys(collection);
   }
 
-  getCrewName(license) {
+  getCrewName(item) {
     let name;
     this.boardings.forEach((boarding) => {
       if (boarding.crew && boarding.crew.length) {
         for (let crew of boarding.crew) {
-          if (crew.license === license) {
+          if (crew.license === item || crew.name === item) {
             name = crew.name;
           }
         }


### PR DESCRIPTION
## Related Issue
Fixes #322 

## Approach
Check for `captain name` if `captain licence` isn't present to identify the crew is a captain and send the respective name to search for data.

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)