### PR TITLE
added one click results display directly into the preview item, now eliminating 2 unnecessary clicks

### DIFF
--- a/src/components/autofill/autofill.css
+++ b/src/components/autofill/autofill.css
@@ -25,3 +25,8 @@
     margin-top: 5px;
     padding-right: 40px;
 }
+
+.preview-item-results-link {
+    text-decoration: none;
+    color: inherit;
+}

--- a/src/components/autofill/preview-item/preview-item.component.js
+++ b/src/components/autofill/preview-item/preview-item.component.js
@@ -56,7 +56,7 @@ const PreviewItem = ({
         </div>
         <div>
           <div className="flex-row font-16">
-            <Link to={searchResultsLink}>
+            <Link className="preview-item-results-link" to={searchResultsLink}>
               <Highlighter
                 highlightClassName="highlighted"
                 searchWords={searchWords}

--- a/src/components/autofill/preview-item/preview-item.component.js
+++ b/src/components/autofill/preview-item/preview-item.component.js
@@ -8,6 +8,8 @@ import RiskIcon from "../../partials/risk-icon/risk-icon.component";
 import TextViewer from "../../partials/text-viewer/text-viewer";
 
 import "../autofill.css";
+import { Link } from "react-router-dom";
+import { BOARDINGS_PAGE, CREW_PAGE, VESSELS_PAGE } from "../../../root/root.constants";
 
 const PreviewItem = ({
   item,
@@ -16,8 +18,20 @@ const PreviewItem = ({
   previewName,
   subText,
   searchWords,
-  t
+  t,
 }) => {
+  let searchResultsLink = "#" 
+  switch(itemName){
+    case "BOARDINGS": searchResultsLink = BOARDINGS_PAGE.replace(":filter", null)
+    break;
+    case "VESSELS": searchResultsLink = VESSELS_PAGE.replace(":filter", null)
+    break;
+    case "CREW MEMBERS": searchResultsLink = CREW_PAGE.replace(":filter", null)
+    break;
+    default: searchResultsLink="#"
+    break;
+  }
+  
   if (!item) return;
 
   const isBoardings = itemName === "BOARDINGS";
@@ -42,12 +56,14 @@ const PreviewItem = ({
         </div>
         <div>
           <div className="flex-row font-16">
-            <Highlighter
-              highlightClassName="highlighted"
-              searchWords={searchWords}
-              autoEscape={true}
-              textToHighlight={name}
-            />
+            <Link to={searchResultsLink}>
+              <Highlighter
+                highlightClassName="highlighted"
+                searchWords={searchWords}
+                autoEscape={true}
+                textToHighlight={name}
+              />
+            </Link>
             {isBoardings && (
               <div className="margin-left">
                 <RiskIcon


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #62 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



