### PR TITLE
was getting agency is null at line 246 of src/helpeers/get-data.js

### DIFF
--- a/src/helpers/get-data.js
+++ b/src/helpers/get-data.js
@@ -243,11 +243,11 @@ export const getSharedAgenciesList = async (name, user) => {
   const agency = await agencyService.getAgencyByName(name);
 
   if (user.agency.admin) {
-    return agency.inboundPartnerAgencies
-      ? [...agency.inboundPartnerAgencies.map((item) => item.name), name]
+    return user.agency.inboundPartnerAgencies
+      ? [...user.agency.inboundPartnerAgencies.map((item) => item.name), name]
       : [name];
   } else {
-    const agencies = agency.inboundPartnerAgencies
+    const agencies = user.agency.inboundPartnerAgencies
       .filter((item) => (item.agencyWideAccess ? item.name : ""))
       .map((el) => el.name);
       


### PR DESCRIPTION
## Related Issue

Fixes the error that boardings, vessels and crew pages just kept loading and threw an error that said 

```
Unhandled Rejection (TypeError): agency is null
getSharedAgenciesList
src/helpers/get-data.js:245
  242 | export const getSharedAgenciesList = async (name, user) => {
  243 |   const agency = await agencyService.getAgencyByName(name);
  244 | 
> 245 |   if (agency.admin) {
  246 |     return agency.inboundPartnerAgencies
  247 |       ? [...agency.inboundPartnerAgencies.map((item) => item.name), name]
  248 |       : [name];
```
And when I look at the source it points to:
```
Unhandled Rejection (TypeError): agency is null
getSharedAgenciesList
http://localhost:3001/static/js/main.chunk.js:28120:7

  28117 | const getSharedAgenciesList = async (name, user) => {
  28118 |   const agency = await agencyService.getAgencyByName(name);
  28119 | 
> 28120 |   if (agency.admin) {
        |       ^  28121 |     return agency.inboundPartnerAgencies ? [...agency.inboundPartnerAgencies.map(item => item.name), name] : [name];
  28122 |   } else {
  28123 |     const agencies = agency.inboundPartnerAgencies.filter(item => item.agencyWideAccess ? item.name : "").map(el => el.name);
```

@jsdmaria I'm not sure this is the right fix, though it did seem to fix the issue. I checked and added any Realm functions that were created, but that did not fix it, so I tried with some code. Let me know what you think.