### PR TITLE
get correct link for PreviewItem and some cleanup of VIEW_BOARDING_PAGE

### DIFF
--- a/src/components/autofill/autofill.component.js
+++ b/src/components/autofill/autofill.component.js
@@ -7,38 +7,53 @@ import PreviewItem from "./preview-item/preview-item.component";
 
 import { SEARCH_RESULTS_PAGE } from "./../../root/root.constants";
 
+import { getCrewViewPageWithFilter, getVesselViewPageWithFilter, getBoardingViewPage } from "../../helpers/get-data"
+
 import "./autofill.css";
 
 class Autofill extends Component {
   render() {
     const { t, vessels, crew, boardings, searchQuery, searchWords } = this.props;
 
+    const firstVessel = vessels[0]
+    const firstCrew = crew[0]
+    const firstBoarding = boardings[0]
+
     return (
       <div className="standard-view white-bg border absolute standard-view autofill">
-        <PreviewItem
-          item={vessels[0]}
-          itemName={t("NAVIGATION.VESSELS").toUpperCase()}
-          icon="vessel"
-          previewName="_id"
-          subText={t("SEARCH.CATCHES")}
-          searchWords={searchWords}
-        />
-        <PreviewItem
-          item={crew[0]}
-          itemName={t("SEARCH.CREW_MEMBERS").toUpperCase()}
-          icon="crew"
-          previewName="name"
-          subText={t("NAVIGATION.VESSELS")}
-          searchWords={searchWords}
-        />
-        <PreviewItem
-          item={boardings[0]}
-          itemName={t("NAVIGATION.BOARDINGS").toUpperCase()}
-          icon="boarding"
-          previewName="date"
-          subText={t("TABLE.VESSEL")}
-          searchWords={searchWords}
-        />
+        {
+          firstVessel && <PreviewItem
+            item={firstVessel}
+            itemName={t("NAVIGATION.VESSELS").toUpperCase()}
+            icon="vessel"
+            previewName="_id"
+            subText={t("SEARCH.CATCHES")}
+            searchWords={searchWords}
+            itemInfoLink={getVesselViewPageWithFilter(firstVessel)}
+          />
+        }
+        {
+          firstCrew && <PreviewItem
+            item={firstCrew}
+            itemName={t("SEARCH.CREW_MEMBERS").toUpperCase()}
+            icon="crew"
+            previewName="name"
+            subText={t("NAVIGATION.VESSELS")}
+            searchWords={searchWords}
+            itemInfoLink={getCrewViewPageWithFilter(firstCrew)}
+          />
+        }
+        {
+          firstBoarding && <PreviewItem
+            item={firstBoarding}
+            itemName={t("NAVIGATION.BOARDINGS").toUpperCase()}
+            icon="boarding"
+            previewName="date"
+            subText={t("TABLE.VESSEL")}
+            searchWords={searchWords}
+            itemInfoLink={getBoardingViewPage(firstBoarding._id)}
+          />
+        }
         <div className="flex-row preview-search">
           <SearchIcon htmlColor='#0a4074'/>
           <NavLink className="custom-link" to={SEARCH_RESULTS_PAGE}>

--- a/src/components/autofill/preview-item/preview-item.component.js
+++ b/src/components/autofill/preview-item/preview-item.component.js
@@ -2,17 +2,17 @@ import React, { memo } from "react";
 import moment from "moment";
 import Highlighter from "react-highlight-words";
 import { withTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 
 import RiskIcon from "../../partials/risk-icon/risk-icon.component";
 
 import TextViewer from "../../partials/text-viewer/text-viewer";
 
 import "../autofill.css";
-import { Link } from "react-router-dom";
-import { BOARDINGS_PAGE, CREW_PAGE, VESSELS_PAGE } from "../../../root/root.constants";
 
 const PreviewItem = ({
   item,
+  itemInfoLink,
   itemName,
   icon,
   previewName,
@@ -20,18 +20,6 @@ const PreviewItem = ({
   searchWords,
   t,
 }) => {
-  let searchResultsLink = "#" 
-  switch(itemName){
-    case "BOARDINGS": searchResultsLink = BOARDINGS_PAGE.replace(":filter", null)
-    break;
-    case "VESSELS": searchResultsLink = VESSELS_PAGE.replace(":filter", null)
-    break;
-    case "CREW MEMBERS": searchResultsLink = CREW_PAGE.replace(":filter", null)
-    break;
-    default: searchResultsLink="#"
-    break;
-  }
-  
   if (!item) return;
 
   const isBoardings = itemName === "BOARDINGS";
@@ -56,7 +44,7 @@ const PreviewItem = ({
         </div>
         <div>
           <div className="flex-row font-16">
-            <Link className="preview-item-results-link" to={searchResultsLink}>
+            <Link className="preview-item-results-link" to={itemInfoLink}>
               <Highlighter
                 highlightClassName="highlighted"
                 searchWords={searchWords}

--- a/src/components/boardings/boarding-edit/boarding-edit.component.js
+++ b/src/components/boardings/boarding-edit/boarding-edit.component.js
@@ -23,9 +23,7 @@ import RiskIcon from "../../partials/risk-icon/risk-icon.component";
 import AuthService from "./../../../services/auth.service";
 import BoardingService from "./../../../services/boarding.service";
 
-import history from "../../../root/root.history";
-
-import { VIEW_BOARDING_PAGE } from "../../../root/root.constants.js";
+import { goBoardingViewPage } from "../../../helpers/get-data"
 
 import "./boardings-edit.css";
 
@@ -62,11 +60,9 @@ class BoardingEditPage extends Component {
     this.validateSchema();
     boardingService.updateBoarding(this.dataObject).then((result) => {
       if (this.state.isNew) {
-        history.push(VIEW_BOARDING_PAGE.replace(":id", result.insertedId));
+        goBoardingViewPage(result.insertedId);
       } else {
-        history.push(
-          VIEW_BOARDING_PAGE.replace(":id", this.state.dataObject._id)
-        );
+        goBoardingViewPage(this.state.dataObject._id);
       }
     });
   };

--- a/src/components/boardings/boardings-table/boardings-table.component.js
+++ b/src/components/boardings/boardings-table/boardings-table.component.js
@@ -7,9 +7,7 @@ import Pagination from "@material-ui/lab/Pagination";
 import ChartBox from "../../charts/chart-box.component";
 import RiskIcon from "./../../partials/risk-icon/risk-icon.component";
 
-import { goToPage } from "./../../../helpers/get-data";
-
-import { VIEW_BOARDING_PAGE } from "../../../root/root.constants.js";
+import { goBoardingViewPage } from "./../../../helpers/get-data";
 
 import StitchService from "./../../../services/stitch.service";
 
@@ -66,7 +64,7 @@ class BoardingsTable extends Component {
                 <tr
                   className="table-row row-body"
                   key={ind}
-                  onClick={() => goToPage(VIEW_BOARDING_PAGE, item._id)}
+                  onClick={() => goBoardingViewPage(item._id)}
                 >
                   <td> {moment(item.date).format("L")}</td>
                   <td> {moment(item.date).format("LT")}</td>

--- a/src/components/partials/overview-pages/boardings-overview/boardings-overview.component.js
+++ b/src/components/partials/overview-pages/boardings-overview/boardings-overview.component.js
@@ -2,13 +2,12 @@ import React, { memo, Fragment } from "react";
 import { withTranslation } from "react-i18next";
 import moment from "moment";
 
-import { goToPage, goToPageWithFilter } from "./../../../../helpers/get-data";
+import { goBoardingViewPage, goToPageWithFilter } from "./../../../../helpers/get-data";
 
 import SeeLink from "../../../partials/see-all-link/see-all-link";
 import RiskIcon from "../../../partials/risk-icon/risk-icon.component";
 
 import {
-  VIEW_BOARDING_PAGE,
   BOARDINGS_PAGE,
 } from "../../../../root/root.constants.js";
 
@@ -43,7 +42,7 @@ const BoardingsOverview = ({ t, boardings, filter }) => (
                   key={ind}
                   className="table-row row-body"
                   onClick={() =>
-                    goToPage(VIEW_BOARDING_PAGE, boarding.id)
+                    goBoardingViewPage(boarding.id)
                   }
                 >
                   <td>{moment(boarding.date).format("L")}</td>

--- a/src/components/partials/overview-pages/violations-overview/violations-overview.component.js
+++ b/src/components/partials/overview-pages/violations-overview/violations-overview.component.js
@@ -2,10 +2,9 @@ import React, { memo, Fragment } from "react";
 import { withTranslation } from "react-i18next";
 import moment from "moment";
 
-import { goToPage, goToPageWithFilter } from "./../../../../helpers/get-data";
+import { goBoardingViewPage, goToPageWithFilter } from "./../../../../helpers/get-data";
 
 import {
-  VIEW_BOARDING_PAGE,
   VIOLATIONS_PAGE,
 } from "../../../../root/root.constants.js";
 
@@ -47,7 +46,7 @@ const ViolationsOverview = ({ t, filter, violations }) => (
                 <td>{moment(violation.boardingDate).format("L")}</td>
                 <td
                   onClick={() =>
-                    goToPage(VIEW_BOARDING_PAGE, violation.boardingId)
+                    goBoardingViewPage(violation.boardingId)
                   }
                 >
                   <SeeLink

--- a/src/components/search-results/boardings/boardings.component.js
+++ b/src/components/search-results/boardings/boardings.component.js
@@ -9,10 +9,10 @@ import RiskIcon from "../../partials/risk-icon/risk-icon.component";
 import {
   getViolations,
   getCatches,
-  goToPage,
+  goBoardingViewPage,
 } from "./../../../helpers/get-data.js";
 
-import { VIEW_BOARDING_PAGE, BOARDINGS_PAGE } from "../../../root/root.constants.js";
+import { BOARDINGS_PAGE } from "../../../root/root.constants.js";
 
 import "../search-results.css";
 
@@ -36,7 +36,7 @@ class FoundBoardings extends Component {
           <div className="items-list">
             <div
               className="flex-row align-center border-bottom padding pointer"
-              onClick={() => goToPage(VIEW_BOARDING_PAGE, boardingsList[0]._id)}
+              onClick={() => goBoardingViewPage(boardingsList[0]._id)}
             >
               <div className="icon-img">
                 <img

--- a/src/helpers/get-data.js
+++ b/src/helpers/get-data.js
@@ -285,15 +285,12 @@ export const goCrewViewPage = (crew) => {
   history.push(getCrewViewPageWithFilter(crew))
 };
 
-// refactored from goToPage
 export const getBoardingViewPage = (boardingId) => {
   let path = VIEW_BOARDING_PAGE;
   path = path.replace(":id", boardingId);
-  path = path.replace(":filter", "null"); 
   return path;
 }
 
-// refactored from goToPage
 export const goBoardingViewPage = (boardingId) => {
   history.push(getBoardingViewPage(boardingId));
 }

--- a/src/helpers/get-data.js
+++ b/src/helpers/get-data.js
@@ -4,7 +4,7 @@ import SearchService from "./../services/search.service";
 
 import history from "../root/root.history";
 
-import { VIEW_CREW_PAGE, VIEW_VESSEL_PAGE } from "../root/root.constants.js";
+import { VIEW_CREW_PAGE, VIEW_VESSEL_PAGE, VIEW_BOARDING_PAGE } from "../root/root.constants.js";
 
 //TODO Show pics in Users list
 // import StitchService from "./../services/stitch.service";
@@ -284,3 +284,16 @@ export const getCrewViewPageWithFilter = (crew) => {
 export const goCrewViewPage = (crew) => {
   history.push(getCrewViewPageWithFilter(crew))
 };
+
+// refactored from goToPage
+export const getBoardingViewPage = (boardingId) => {
+  let path = VIEW_BOARDING_PAGE;
+  path = path.replace(":id", boardingId);
+  path = path.replace(":filter", "null"); 
+  return path;
+}
+
+// refactored from goToPage
+export const goBoardingViewPage = (boardingId) => {
+  history.push(getBoardingViewPage(boardingId));
+}


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #353

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 

- removed the incorrect link with null filters in PreviewItem
- used get*ViewPage methods from get-data to get link for Vessels, Crews, and Boardings
- make sure that PreviewItem is not rendered when item not there yet
- added a reusable method getBoardingViewPage to get-data

Additional:
- cleanup all usage of VIEW_BOARDING_PAGE into reusable goBoardingViewPage


* **Optional: Add any relevant screenshots here** 



