### PR TITLE
Fix images require default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # testing
 /coverage
 /.vscode
+/.eslintcache
 
 # production
 /build

--- a/src/components/agencies/agencies.component.js
+++ b/src/components/agencies/agencies.component.js
@@ -170,7 +170,7 @@ class AgenciesMain extends React.Component {
               {t("FILTER.FILTER")}
               <img
                 className="custom-down-arrow"
-                src={require("../../assets/angle-arrow-down.svg")}
+                src={require("../../assets/angle-arrow-down.svg").default}
                 alt="no arrow img"
               />
             </div>

--- a/src/components/agencies/data-sharing/see-shared-data-dialog/see-shared-data-dialog.js
+++ b/src/components/agencies/data-sharing/see-shared-data-dialog/see-shared-data-dialog.js
@@ -117,7 +117,7 @@ class SeeSharedDataDialog extends Component {
                                 <div className="green-mark">
                                   <img
                                     className="full-view"
-                                    src={require("../../../../assets/done-mark.svg")}
+                                    src={require("../../../../assets/done-mark.svg").default}
                                     alt="Use/change this filter"
                                   />
                                 </div>

--- a/src/components/agencies/data-sharing/share-data-dialog/share-data-dialog.js
+++ b/src/components/agencies/data-sharing/share-data-dialog/share-data-dialog.js
@@ -71,7 +71,7 @@ class ShareDataDialog extends Component {
               <div className="arrow-right">
                 <img
                   className="icon"
-                  src={require("../../../../assets/right-arrow.svg")}
+                  src={require("../../../../assets/right-arrow.svg").default}
                   alt="no arrow img"
                 />
               </div>

--- a/src/components/agencies/view-agency/view-agency.component.js
+++ b/src/components/agencies/view-agency/view-agency.component.js
@@ -111,7 +111,7 @@ class ViewAgency extends Component {
                   <div className="agency-box-img">
                     <img
                       className="icon"
-                      src={require("../../../assets/site-icon.png")}
+                      src={require("../../../assets/site-icon.png").default}
                       alt="no logo"
                     />
                   </div>
@@ -121,7 +121,7 @@ class ViewAgency extends Component {
                   <div className="agency-box-img">
                     <img
                       className="icon"
-                      src={require("../../../assets/email-icon.png")}
+                      src={require("../../../assets/email-icon.png").default}
                       alt="no logo"
                     />
                   </div>

--- a/src/components/autofill/preview-item/preview-item.component.js
+++ b/src/components/autofill/preview-item/preview-item.component.js
@@ -38,7 +38,7 @@ const PreviewItem = ({
         <div className="preview-item-img">
           <img
             className="full-view"
-            src={require(`../../../assets/${icon}-icon.png`)}
+            src={require(`../../../assets/${icon}-icon.png`).default}
             alt="no icon"
           />
         </div>

--- a/src/components/boardings/boarding-edit/vessel/vessel.section.js
+++ b/src/components/boardings/boarding-edit/vessel/vessel.section.js
@@ -146,7 +146,7 @@ class VesselSection extends Component {
                   <div className="nationality-img">
                     <img
                       className="full-view"
-                      src={require("../../../../assets/nationality.png")}
+                      src={require("../../../../assets/nationality.png").default}
                       alt="no icon"
                     />
                   </div>

--- a/src/components/boardings/boarding-new/control-buttons/control-buttons.js
+++ b/src/components/boardings/boarding-new/control-buttons/control-buttons.js
@@ -19,7 +19,7 @@ const ControlButtons = ({t, onCancel, onSave}) => {
 				{t("BUTTONS.SAVE_BOARDING")}
 				<img
 					className="custom-down-arrow"
-					src={require("../../../../assets/angle-arrow-down.svg")}
+					src={require("../../../../assets/angle-arrow-down.svg").default}
 					alt="no arrow img"
 				/>
 				{isMenuShown && (

--- a/src/components/crew/crew-view/crew-view.component.js
+++ b/src/components/crew/crew-view/crew-view.component.js
@@ -136,7 +136,7 @@ class CrewViewPage extends Component {
                                   <div className="sm-photo-icon">
                                     <img
                                       className="icon"
-                                      src={require("../../../assets/photo-icon.png")}
+                                      src={require("../../../assets/photo-icon.png").default}
                                       alt="no logo"
                                     />
                                   </div>

--- a/src/components/dashboards/agencies-dashboard.component.js
+++ b/src/components/dashboards/agencies-dashboard.component.js
@@ -138,7 +138,7 @@ class AgenciesDashboard extends Component {
                   <div className="blue-btn filter-btn">
                     <img
                       className="icon"
-                      src={require("../../assets/filter-icon.png")}
+                      src={require("../../assets/filter-icon.png").default}
                       alt="no logo"
                     />
                   </div>

--- a/src/components/header/header.component.js
+++ b/src/components/header/header.component.js
@@ -113,7 +113,7 @@ class Header extends Component {
               <div className="header-logo-img">
                 <img
                   className="icon"
-                  src={require("../../assets/logo.png")}
+                  src={require("../../assets/logo.png").default}
                   alt="no logo"
                 />
               </div>
@@ -137,7 +137,7 @@ class Header extends Component {
                         </div>
                         <img
                           className="custom-down-arrow"
-                          src={require("../../assets/angle-arrow-down.svg")}
+                          src={require("../../assets/angle-arrow-down.svg").default}
                           alt="no arrow img"
                         />
                       </div>
@@ -188,7 +188,7 @@ class Header extends Component {
                       </div>
                       <img
                         className="custom-down-arrow"
-                        src={require("../../assets/angle-arrow-down.svg")}
+                        src={require("../../assets/angle-arrow-down.svg").default}
                         alt="no arrow img"
                       />
                     </div>
@@ -226,7 +226,7 @@ class Header extends Component {
                       <div className="nav-item">{t("NAVIGATION.USERS")}</div>
                       <img
                         className="custom-down-arrow"
-                        src={require("../../assets/angle-arrow-down.svg")}
+                        src={require("../../assets/angle-arrow-down.svg").default}
                         alt="no arrow img"
                       />
                     </div>
@@ -287,7 +287,7 @@ class Header extends Component {
                     </div>
                     <img
                       className="custom-down-arrow"
-                      src={require("../../assets/angle-arrow-down.svg")}
+                      src={require("../../assets/angle-arrow-down.svg").default}
                       alt="no arrow img"
                     />
                   </div>

--- a/src/components/login/login.component.js
+++ b/src/components/login/login.component.js
@@ -63,7 +63,7 @@ class Login extends Component {
             <div className="login-logo-img">
               <img
                 className="full-view"
-                src={require("../../assets/login-logo.png")}
+                src={require("../../assets/login-logo.png").default}
                 alt="WildAid O-Fish. Powered by MongoDB."
               />
             </div>

--- a/src/components/partials/custom-select/custom-select.js
+++ b/src/components/partials/custom-select/custom-select.js
@@ -54,7 +54,7 @@ class CustomSelect extends Component {
           <div className="arrow">
             <img
               className="icon"
-              src={require("../../../assets/filled-arrow.svg")}
+              src={require("../../../assets/filled-arrow.svg").default}
               alt="Use/Change this filter"
             />
           </div>

--- a/src/components/partials/filter-panel/filter-part.component.js
+++ b/src/components/partials/filter-panel/filter-part.component.js
@@ -130,7 +130,7 @@ class FilterPart extends Component {
             >
           <img
               className="icon"
-              src={require("../../../assets/filled-arrow.svg")}
+              src={require("../../../assets/filled-arrow.svg").default}
               alt="Use/change this filter"
             />
             </div>

--- a/src/components/partials/filter-panel/filter-risk.component.js
+++ b/src/components/partials/filter-panel/filter-risk.component.js
@@ -97,7 +97,7 @@ export default class FilterPartForRisk extends Component {
           <div className="show-panel-btn" onClick={this.showSearchPanel}>
           <img
               className="icon"
-              src={require("../../../assets/filled-arrow.svg")}
+              src={require("../../../assets/filled-arrow.svg").default}
               alt="Use/change this filter"
             />
           </div>

--- a/src/components/partials/item-info/item-info.js
+++ b/src/components/partials/item-info/item-info.js
@@ -24,7 +24,7 @@ const ItemInfo = ({
       <div className="padding-right icon-img">
         <img
           className="full-view"
-          src={require(`../../../assets/${icon}-icon.png`)}
+          src={require(`../../../assets/${icon}-icon.png`).default}
           alt="no icon"
         />
       </div>

--- a/src/components/partials/overview-pages/photo-overview/photo-overview.component.js
+++ b/src/components/partials/overview-pages/photo-overview/photo-overview.component.js
@@ -32,7 +32,7 @@ const PhotosOverview = ({ t, photos, photosId, filter }) => (
                 {/* <UserPhoto imageId={photo.url} defaultIcon={false} /> */}
                 <img
                   className="icon"
-                  src={require("../../../../assets/photo-big-icon.png")}
+                  src={require("../../../../assets/photo-big-icon.png").default}
                   alt="no logo"
                 />
               </div>

--- a/src/components/partials/photo-uploader/photo-uploader.component.js
+++ b/src/components/partials/photo-uploader/photo-uploader.component.js
@@ -85,7 +85,7 @@ export default class PhotoUploader extends Component {
                 ? imgData
                 : src
                 ? src
-                : require("../../../assets/download-img-icon.jpg")
+                : require("../../../assets/download-img-icon.jpg").default
             }
             alt="no logo"
           />

--- a/src/components/partials/user-photo/user-photo.component.js
+++ b/src/components/partials/user-photo/user-photo.component.js
@@ -59,7 +59,7 @@ class UserPhoto extends Component {
               userPhoto ||
               require(`../../../assets/user${
                 defaultIcon ? "-header" : ""
-              }-icon.png`)
+              }-icon.png`).default
             }
             alt="no user"
           />

--- a/src/components/photos/photos.component.js
+++ b/src/components/photos/photos.component.js
@@ -189,7 +189,7 @@ class PhotosPage extends Component {
                         <div className="photo-icon">
                           <img
                             className="icon"
-                            src={require("../../assets/photo-big-icon.png")}
+                            src={require("../../assets/photo-big-icon.png").default}
                             alt="no logo"
                           />
                         </div>

--- a/src/components/restore-password/reset-password.component.js
+++ b/src/components/restore-password/reset-password.component.js
@@ -64,7 +64,7 @@ class ResetPassword extends Component {
             <div className="login-logo-img">
               <img
                 className="full-view"
-                src={require("../../assets/login-logo.png")}
+                src={require("../../assets/login-logo.png").default}
                 alt="no logo"
               />
             </div>

--- a/src/components/restore-password/restore-password.component.js
+++ b/src/components/restore-password/restore-password.component.js
@@ -44,7 +44,7 @@ class RestorePassword extends Component {
             <div className="login-logo-img">
               <img
                 className="full-view"
-                src={require("../../assets/login-logo.png")}
+                src={require("../../assets/login-logo.png").default}
                 alt="no logo"
               />
             </div>

--- a/src/components/search-results/boardings/boardings.component.js
+++ b/src/components/search-results/boardings/boardings.component.js
@@ -41,7 +41,7 @@ class FoundBoardings extends Component {
               <div className="icon-img">
                 <img
                   className="full-view"
-                  src={require(`../../../assets/boarding-icon.png`)}
+                  src={require(`../../../assets/boarding-icon.png`).default}
                   alt="no icon"
                 />
               </div>

--- a/src/components/users/users.component.js
+++ b/src/components/users/users.component.js
@@ -175,7 +175,7 @@ class UsersMain extends React.Component {
               {t("FILTER.FILTER")}
               <img
                 className="custom-down-arrow"
-                src={require("../../assets/angle-arrow-down.svg")}
+                src={require("../../assets/angle-arrow-down.svg").default}
                 alt="no arrow img"
               />
             </div>

--- a/src/components/vessels/vessel-view/vessel-view.component.js
+++ b/src/components/vessels/vessel-view/vessel-view.component.js
@@ -162,7 +162,7 @@ class VesselViewPage extends Component {
                                   <div className="sm-photo-icon">
                                     <img
                                       className="icon"
-                                      src={require("../../../assets/photo-icon.png")}
+                                      src={require("../../../assets/photo-icon.png").default}
                                       alt="no logo"
                                     />
                                   </div>


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes # 376

PR #376 introduced a bug on upgrade where image loads that were fine before, are not. This seems to be because of the react-scripts upgrade. Appending .default at the end of the require worked (I would have preferred to change the webpack.config.js but we're using react-scripts so that's more complicated.

See also https://stackoverflow.com/questions/59070216/webpack-file-loader-outputs-object-module
