### PR TITLE
Navbar items now close on blur

### DIFF
--- a/src/components/header/header.component.js
+++ b/src/components/header/header.component.js
@@ -127,11 +127,12 @@ class Header extends Component {
                     </NavLink>
                   )}
                   {isItemShown && (
-                    <div className="relative nav-menu-item">
-                      <div
-                        className="flex-row align-baseline pointer"
-                        onMouseEnter={() => this.showActiveMenu("dashboard")}
-                      >
+                    <div
+                      className="flex-row align-center relative nav-menu-item pointer"
+                      onMouseEnter={() => this.showActiveMenu("dashboard")}
+                      onMouseLeave={() => this.showActiveMenu()}
+                    >
+                      <div className="flex-row">
                         <div className="nav-item">
                           {t("NAVIGATION.DASHBOARD")}
                         </div>
@@ -178,11 +179,12 @@ class Header extends Component {
                       )}
                     </div>
                   )}
-                  <div className="relative nav-menu-item">
-                    <div
-                      className="flex-row align-baseline pointer"
-                      onMouseEnter={() => this.showActiveMenu("boarding")}
-                    >
+                  <div
+                    className="flex-row align-center relative nav-menu-item pointer"
+                    onMouseEnter={() => this.showActiveMenu("boarding")}
+                    onMouseLeave={() => this.showActiveMenu()}
+                  >
+                    <div className="flex-row">
                       <div className="nav-item">
                         {t("NAVIGATION.BOARDING_RECORDS")}
                       </div>
@@ -218,11 +220,12 @@ class Header extends Component {
                       </div>
                     )}
                   </div>
-                  <div className="relative nav-menu-item">
-                    <div
-                      className="flex-row align-baseline pointer"
-                      onMouseEnter={() => this.showActiveMenu("users")}
-                    >
+                  <div
+                    className="flex-row align-center relative nav-menu-item pointer"
+                    onMouseEnter={() => this.showActiveMenu("users")}
+                    onMouseLeave={() => this.showActiveMenu()}
+                  >
+                    <div className="flex-row">
                       <div className="nav-item">{t("NAVIGATION.USERS")}</div>
                       <img
                         className="custom-down-arrow"
@@ -249,18 +252,20 @@ class Header extends Component {
                       </div>
                     )}
                   </div>
-                  {(currentUser.global.admin || currentUser.agency.admin) && (
-                    <NavLink
-                      className="nav-menu-item"
-                      to={AGENCIES_PAGE}
-                      onMouseLeave={this.navigate}
-                    >
-                      {t("NAVIGATION.AGENCIES")}
-                    </NavLink>
+                  {(currentUser.global.admin || currentUser.agency.admin) && (                    
+                      <NavLink      
+                        className="flex-row align-center nav-menu-item"                                        
+                        to={AGENCIES_PAGE}
+                        onMouseLeave={this.navigate}
+                      >
+                        {t("NAVIGATION.AGENCIES")}
+                      </NavLink>                                
                   )}
                   {currentUser.agency.admin && !currentUser.global.admin && (
                     <NavLink
-                      className={`nav-menu-item ${dataSharingDot ? "data-sharing-tab" : ""}`}
+                      className={`flex-row align-center nav-menu-item ${
+                        dataSharingDot ? "data-sharing-tab" : ""
+                      }`}
                       to={DATA_SHARING_PAGE}
                       onMouseLeave={this.navigate}
                       onClick={this.removeTabDot}
@@ -269,11 +274,11 @@ class Header extends Component {
                     </NavLink>
                   )}
                 </div>
-                <div
-                  className="relative"
+                <div className="relative nav-menu-item pointer"
                   onMouseEnter={() => this.showActiveMenu("profile")}
+                  onMouseLeave={() => this.showActiveMenu()}
                 >
-                  <div className="flex-row pointer">
+                  <div className="flex-row align-center">
                     <div className="flex-row align-center">
                       <UserPhoto
                         imageId={currentUser ? currentUser.profilePic : null}

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -13,7 +13,7 @@
   border-radius: 5px;
   z-index: 6;
   width: 132px;
-  top: 25px;
+  top: 40px;
   color: black;
 }
 
@@ -39,7 +39,7 @@
 
 .profile-menu {
   width: 142px;
-  top: 47px;
+  top: 40px;
   left: 10px;
 }
 
@@ -69,7 +69,8 @@
 .nav-menu-item {
   color: white;
   text-decoration: none;
-  margin-right: 45px;
+  margin-right: 45px;  
+  height:45px;
 }
 
 .data-sharing-tab {


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #399 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 
 
Needed to wrap the menu into the div with the onMouseLeave events so they had expected behaviour.
**New to open source so happy to get feedback** want to be a positive contributor while participating in Hacktoberfest 


* **Optional: Add any relevant screenshots here** 



