### PR TITLE
Added a path property to the search options

### DIFF
--- a/src/components/partials/custom-select/custom-select.js
+++ b/src/components/partials/custom-select/custom-select.js
@@ -8,13 +8,13 @@ import { resetSearch } from "./../../../helpers/get-data";
 import "./custom-select.css";
 
 const SEARCH_OPTIONS = [
-  { name: "All", translateKey: "SEARCH.ALL" },
-  { name: "Boardings", translateKey: "NAVIGATION.BOARDINGS" },
-  { name: "Vessels", translateKey: "NAVIGATION.VESSELS" },
-  { name: "Crew", translateKey: "NAVIGATION.CREW" },
-  { name: "Users", translateKey: "NAVIGATION.USERS" },
-  { name: "Agencies", translateKey: "NAVIGATION.AGENCIES" },
-  { name: "Reports", translateKey: "SEARCH.REPORTS" },
+  { name: "All", translateKey: "SEARCH.ALL", path: "home" },
+  { name: "Boardings", translateKey: "NAVIGATION.BOARDINGS", path: "boardings/null" },
+  { name: "Vessels", translateKey: "NAVIGATION.VESSELS", path: "vessels/null" },
+  { name: "Crew", translateKey: "NAVIGATION.CREW", path: "crew/null" },
+  { name: "Users", translateKey: "NAVIGATION.USERS", path: "users" },
+  { name: "Agencies", translateKey: "NAVIGATION.AGENCIES", path: "agencies" },
+  { name: "Reports", translateKey: "SEARCH.REPORTS", path: "reports" },
 ];
 
 class CustomSelect extends Component {
@@ -24,7 +24,7 @@ class CustomSelect extends Component {
   };
 
   setSelected = (option) => {
-    const newPath = option === "All" ? "home" : option.toLowerCase();
+    const newPath = !option ? "home" : option.toLowerCase();
     history.push(`/${newPath}`);
 
     resetSearch();
@@ -65,7 +65,7 @@ class CustomSelect extends Component {
               <div
                 className="option"
                 key={key}
-                onClick={() => this.setSelected(option.name)}
+                onClick={() => this.setSelected(option.path)}
               >
                 {t(option.translateKey)}
               </div>


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #382

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 
With some of the pages now expecting a "null" for no filter options, I thought just adding a custom path for each option made sense.

It can be customised easily if any changes occur in the future. The label is also no longer tied to the path taken.

I couldn't find a path for "Reports" I am assuming they are just not implemented yet, let me know if that needs changing 😊


* **Optional: Add any relevant screenshots here** 



