### PR TITLE
Corrects spelling error on Activities page

### DIFF
--- a/src/components/users/activities/activities.component.js
+++ b/src/components/users/activities/activities.component.js
@@ -4,7 +4,7 @@ class UsersActivities extends Component {
   render() {
     return (
       <div className="activities-page">
-        Acticities page
+        Activities page
       </div>
     );
   }


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [ ] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 
It might be that this change should have been an i18N string to start with, but this is a simple fix on the spelling, that was not a i18N string to start with.


* **Optional: Add any relevant screenshots here** 

<img width="423" alt="acticities" src="https://user-images.githubusercontent.com/451/142483846-dad250b9-158a-4e27-b9b7-0ea9f18d6bbc.png">


