### PR TITLE
Violation page - violation shows the wrong field

### DIFF
--- a/src/components/violations/violations.component.js
+++ b/src/components/violations/violations.component.js
@@ -174,7 +174,7 @@ class ViolationsPage extends Component {
                       <td>
                         <div className="flex-column">
                           <div>{violation.violation}</div>
-                          <div>{violation.license}</div>
+                          <div>{violation.code}</div>
                         </div>
                       </td>
                       <td>{violation.result}</td>


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #454 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [ ] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [ ] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



